### PR TITLE
[Feature] Implement `expect.each().resolves` and `.rejects` as prototype

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -9,8 +9,8 @@ module.exports.setup = function () {
    */
   expect.each = function (actualTable) {
     const expectProxy = new Proxy(expect, {
-      get (target, matcher) {
-        if (matcher === 'not') {
+      get (target, propertyName) {
+        if (propertyName === 'not') {
           return new Proxy(expect, {
             get (target, matcher) {
               return (expectedArgs) => {
@@ -32,7 +32,7 @@ module.exports.setup = function () {
               [it, expectedArgs[index]]
             )
             .find(([actual, expect]) =>
-              target(actual)[matcher](expect)
+              target(actual)[propertyName](expect)
             )
         }
       }

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -7,69 +7,65 @@ module.exports.setup = function () {
    * @param {Array<*>} actualTable - Test table.
    * @returns {Proxy<expect>} - Proxy of expect.
    */
-  expect.each = function (actualTable) {
-    const expectProxy = new Proxy(expect, {
-      get (target, propertyName) {
-        if (['rejects', 'resolves'].includes(propertyName)) {
-          return new Proxy(expect, {
-            get (target, matcher) {
-              if (matcher === 'not') {
-                return new Proxy(expect, {
-                  get (target, matcher) {
-                    return async (expectedArgs) => Promise.allSettled(
-                      actualTable
-                        .map((it, index) =>
-                          [it, expectedArgs[index]]
-                        )
-                        .map(([actual, expected]) =>
-                          target(actual)[propertyName].not[matcher](expected)
-                        )
-                    )
-                  }
-                })
-              }
-
-              return (expectedArgs) => Promise.allSettled(
-                actualTable
-                  .map((it, index) =>
-                    [it, expectedArgs[index]]
+  expect.each = (actualTable) => new Proxy(expect, {
+    get (target, propertyName) {
+      if (['rejects', 'resolves'].includes(propertyName)) {
+        return new Proxy(expect, {
+          get (target, matcher) {
+            if (matcher === 'not') {
+              return new Proxy(expect, {
+                get (target, matcher) {
+                  return async (expectedArgs) => Promise.allSettled(
+                    actualTable
+                      .map((it, index) =>
+                        [it, expectedArgs[index]]
+                      )
+                      .map(([actual, expected]) =>
+                        target(actual)[propertyName].not[matcher](expected)
+                      )
                   )
-                  .map(([actual, expected]) =>
-                    target(actual)[propertyName][matcher](expected)
-                  )
-              )
+                }
+              })
             }
-          })
-        }
 
-        if (propertyName === 'not') {
-          return new Proxy(expect, {
-            get (target, matcher) {
-              return (expectedArgs) => {
-                actualTable
-                  .map((it, index) =>
-                    [it, expectedArgs[index]]
-                  )
-                  .find(([actual, expected]) =>
-                    target(actual).not[matcher](expected)
-                  )
-              }
-            }
-          })
-        }
-
-        return (expectedArgs) => {
-          actualTable
-            .map((it, index) =>
-              [it, expectedArgs[index]]
+            return (expectedArgs) => Promise.allSettled(
+              actualTable
+                .map((it, index) =>
+                  [it, expectedArgs[index]]
+                )
+                .map(([actual, expected]) =>
+                  target(actual)[propertyName][matcher](expected)
+                )
             )
-            .find(([actual, expected]) =>
-              target(actual)[propertyName](expected)
-            )
-        }
+          }
+        })
       }
-    })
 
-    return expectProxy
-  }
+      if (propertyName === 'not') {
+        return new Proxy(expect, {
+          get (target, matcher) {
+            return (expectedArgs) => {
+              actualTable
+                .map((it, index) =>
+                  [it, expectedArgs[index]]
+                )
+                .find(([actual, expected]) =>
+                  target(actual).not[matcher](expected)
+                )
+            }
+          }
+        })
+      }
+
+      return (expectedArgs) => {
+        actualTable
+          .map((it, index) =>
+            [it, expectedArgs[index]]
+          )
+          .find(([actual, expected]) =>
+            target(actual)[propertyName](expected)
+          )
+      }
+    }
+  })
 }

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -64,14 +64,14 @@ function createExpectCaller ({
   propertyChains,
 }) {
   return actualValues
-    .map((it, index) =>
-      [it, expectedValues[index]]
-    )
-    .map(([actual, expected]) =>
+    .map(value =>
       propertyChains.reduce(
-        (accumulator, it) => accumulator[it],
-        expect(actual)
-      )(expected)
+        (receiver, it) => receiver[it],
+        expect(value)
+      )
+    )
+    .map((matcher, index) =>
+      matcher(expectedValues[index])
     )
 }
 

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -9,12 +9,16 @@ module.exports.setup = function () {
    */
   expect.each = (actualTable) => new Proxy(expect, {
     get (_, propertyName) {
-      return expectProxyCreators[propertyName]?.(actualTable)
-        ?? ((expectedArgs) => createExpectCaller({
+      if (expectProxyCreators[propertyName]) {
+        return expectProxyCreators[propertyName](actualTable)
+      }
+
+      return (expectedArgs) =>
+        createExpectCaller({
           actualTable,
           expectedArgs,
           propertyChains: [propertyName]
-        }))
+        })
     }
   })
 }

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -4,18 +4,18 @@ module.exports.setup = function () {
   /**
    * Extend each() to expect of Jest method.
    *
-   * @param {Array<*>} actualTable - Test table.
+   * @param {Array<*>} actualValues - Test table.
    * @returns {Proxy<expect>} - Proxy of expect.
    */
-  expect.each = (actualTable) => new Proxy(expect, {
+  expect.each = (actualValues) => new Proxy(expect, {
     get (_, propertyName) {
       if (expectProxyCreators[propertyName]) {
-        return expectProxyCreators[propertyName](actualTable)
+        return expectProxyCreators[propertyName](actualValues)
       }
 
       return (expectedValues) =>
         createExpectCaller({
-          actualTable,
+          actualValues,
           expectedValues,
           propertyChains: [propertyName]
         })
@@ -25,11 +25,11 @@ module.exports.setup = function () {
 
 /** @type {Object.<string, Function>}} creators */
 const expectProxyCreators = {
-  not: (actualTable) => new Proxy(expect, {
+  not: (actualValues) => new Proxy(expect, {
     get (_, matcher) {
       return (expectedValues) =>
         createExpectCaller({
-          actualTable,
+          actualValues,
           expectedValues,
           propertyChains: [
             'not',
@@ -38,12 +38,12 @@ const expectProxyCreators = {
         })
     }
   }),
-  rejects: (actualTable) => createExpectProxyAsPromise({
-    actualTable,
+  rejects: (actualValues) => createExpectProxyAsPromise({
+    actualValues,
     promiseMethod: 'rejects',
   }),
-  resolves: (actualTable) => createExpectProxyAsPromise({
-    actualTable,
+  resolves: (actualValues) => createExpectProxyAsPromise({
+    actualValues,
     promiseMethod: 'resolves',
   }),
 }
@@ -52,18 +52,18 @@ const expectProxyCreators = {
  * Create expect caller.
  *
  * @param {{
- *   actualTable: Array<*>,
+ *   actualValues: Array<*>,
  *   expectedValues: Array<*>,
  *   propertyChains: Array<string>,
  * }} params
  * @returns {Array<*>} - Callers.
  */
 function createExpectCaller ({
-  actualTable,
+  actualValues,
   expectedValues,
   propertyChains,
 }) {
-  return actualTable
+  return actualValues
     .map((it, index) =>
       [it, expectedValues[index]]
     )
@@ -79,13 +79,13 @@ function createExpectCaller ({
  * Create expect proxy with Promise.allSettled.
  *
  * @param {{
- *   actualTable: Array<*>,
+ *   actualValues: Array<*>,
  *   promiseMethod: string,
  * }} params
  * @returns {Proxy} - Proxy for expect methods.
  */
 function createExpectProxyAsPromise ({
-  actualTable,
+  actualValues,
   promiseMethod,
 }) {
   return new Proxy(expect, {
@@ -95,7 +95,7 @@ function createExpectProxyAsPromise ({
           get (_, matcher) {
             return (expectedValues) => Promise.allSettled(
               createExpectCaller({
-                actualTable,
+                actualValues,
                 expectedValues,
                 propertyChains: [
                   promiseMethod,
@@ -110,7 +110,7 @@ function createExpectProxyAsPromise ({
 
       return (expectedValues) => Promise.allSettled(
         createExpectCaller({
-          actualTable,
+          actualValues,
           expectedValues,
           propertyChains: [
             promiseMethod,

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -9,65 +9,39 @@ module.exports.setup = function () {
    */
   expect.each = (actualTable) => new Proxy(expect, {
     get (_, propertyName) {
-      if (['rejects', 'resolves'].includes(propertyName)) {
-        return new Proxy(expect, {
-          get (_, matcher) {
-            if (matcher === 'not') {
-              return new Proxy(expect, {
-                get (_, matcher) {
-                  return (expectedArgs) => Promise.allSettled(
-                    createExpectCaller({
-                      actualTable,
-                      expectedArgs,
-                      propertyChains: [
-                        propertyName,
-                        'not',
-                        matcher
-                      ]
-                    })
-                  )
-                }
-              })
-            }
+      return expectProxyCreators[propertyName]?.(actualTable)
+        ?? ((expectedArgs) => createExpectCaller({
+          actualTable,
+          expectedArgs,
+          propertyChains: [propertyName]
+        }))
+    }
+  })
+}
 
-            return (expectedArgs) => Promise.allSettled(
-              createExpectCaller({
-                actualTable,
-                expectedArgs,
-                propertyChains: [
-                  propertyName,
-                  matcher
-                ]
-              })
-            )
-          }
-        })
-      }
-
-      if (propertyName === 'not') {
-        return new Proxy(expect, {
-          get (_, matcher) {
-            return (expectedArgs) =>
-              createExpectCaller({
-                actualTable,
-                expectedArgs,
-                propertyChains: [
-                  'not',
-                  matcher
-                ]
-              })
-          }
-        })
-      }
-
+/** @type {Object.<string, Function>}} creators */
+const expectProxyCreators = {
+  not: (actualTable) => new Proxy(expect, {
+    get (_, matcher) {
       return (expectedArgs) =>
         createExpectCaller({
           actualTable,
           expectedArgs,
-          propertyChains: [propertyName]
+          propertyChains: [
+            'not',
+            matcher
+          ]
         })
     }
-  })
+  }),
+  rejects: (actualTable) => createExpectProxyAsPromise({
+    actualTable,
+    promiseMethod: 'rejects',
+  }),
+  resolves: (actualTable) => createExpectProxyAsPromise({
+    actualTable,
+    promiseMethod: 'resolves',
+  }),
 }
 
 /**
@@ -95,4 +69,51 @@ function createExpectCaller ({
         expect(actual)
       )(expected)
     )
+}
+
+/**
+ * Create expect proxy with Promise.allSettled.
+ *
+ * @param {{
+ *   actualTable: Array<*>,
+ *   promiseMethod: string,
+ * }} params
+ * @returns {Proxy} - Proxy for expect methods.
+ */
+function createExpectProxyAsPromise ({
+  actualTable,
+  promiseMethod,
+}) {
+  return new Proxy(expect, {
+    get (_, matcher) {
+      if (matcher === 'not') {
+        return new Proxy(expect, {
+          get (_, matcher) {
+            return (expectedArgs) => Promise.allSettled(
+              createExpectCaller({
+                actualTable,
+                expectedArgs,
+                propertyChains: [
+                  promiseMethod,
+                  'not',
+                  matcher
+                ]
+              })
+            )
+          }
+        })
+      }
+
+      return (expectedArgs) => Promise.allSettled(
+        createExpectCaller({
+          actualTable,
+          expectedArgs,
+          propertyChains: [
+            promiseMethod,
+            matcher
+          ]
+        })
+      )
+    }
+  })
 }

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -10,6 +10,38 @@ module.exports.setup = function () {
   expect.each = function (actualTable) {
     const expectProxy = new Proxy(expect, {
       get (target, propertyName) {
+        if (['rejects', 'resolves'].includes(propertyName)) {
+          return new Proxy(expect, {
+            get (target, matcher) {
+              if (matcher === 'not') {
+                return new Proxy(expect, {
+                  get (target, matcher) {
+                    return async (expectedArgs) => Promise.allSettled(
+                      actualTable
+                        .map((it, index) =>
+                          [it, expectedArgs[index]]
+                        )
+                        .map(([actual, expected]) =>
+                          target(actual)[propertyName].not[matcher](expected)
+                        )
+                    )
+                  }
+                })
+              }
+
+              return (expectedArgs) => Promise.allSettled(
+                actualTable
+                  .map((it, index) =>
+                    [it, expectedArgs[index]]
+                  )
+                  .map(([actual, expected]) =>
+                    target(actual)[propertyName][matcher](expected)
+                  )
+              )
+            }
+          })
+        }
+
         if (propertyName === 'not') {
           return new Proxy(expect, {
             get (target, matcher) {

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -18,8 +18,8 @@ module.exports.setup = function () {
                   .map((it, index) =>
                     [it, expectedArgs[index]]
                   )
-                  .find(([actual, expect]) =>
-                    target(actual).not[matcher](expect)
+                  .find(([actual, expected]) =>
+                    target(actual).not[matcher](expected)
                   )
               }
             }
@@ -31,8 +31,8 @@ module.exports.setup = function () {
             .map((it, index) =>
               [it, expectedArgs[index]]
             )
-            .find(([actual, expect]) =>
-              target(actual)[propertyName](expect)
+            .find(([actual, expected]) =>
+              target(actual)[propertyName](expected)
             )
         }
       }

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -8,34 +8,37 @@ module.exports.setup = function () {
    * @returns {Proxy<expect>} - Proxy of expect.
    */
   expect.each = (actualTable) => new Proxy(expect, {
-    get (target, propertyName) {
+    get (_, propertyName) {
       if (['rejects', 'resolves'].includes(propertyName)) {
         return new Proxy(expect, {
-          get (target, matcher) {
+          get (_, matcher) {
             if (matcher === 'not') {
               return new Proxy(expect, {
-                get (target, matcher) {
-                  return async (expectedArgs) => Promise.allSettled(
-                    actualTable
-                      .map((it, index) =>
-                        [it, expectedArgs[index]]
-                      )
-                      .map(([actual, expected]) =>
-                        target(actual)[propertyName].not[matcher](expected)
-                      )
+                get (_, matcher) {
+                  return (expectedArgs) => Promise.allSettled(
+                    createExpectCaller({
+                      actualTable,
+                      expectedArgs,
+                      propertyChains: [
+                        propertyName,
+                        'not',
+                        matcher
+                      ]
+                    })
                   )
                 }
               })
             }
 
             return (expectedArgs) => Promise.allSettled(
-              actualTable
-                .map((it, index) =>
-                  [it, expectedArgs[index]]
-                )
-                .map(([actual, expected]) =>
-                  target(actual)[propertyName][matcher](expected)
-                )
+              createExpectCaller({
+                actualTable,
+                expectedArgs,
+                propertyChains: [
+                  propertyName,
+                  matcher
+                ]
+              })
             )
           }
         })
@@ -43,29 +46,53 @@ module.exports.setup = function () {
 
       if (propertyName === 'not') {
         return new Proxy(expect, {
-          get (target, matcher) {
-            return (expectedArgs) => {
-              actualTable
-                .map((it, index) =>
-                  [it, expectedArgs[index]]
-                )
-                .find(([actual, expected]) =>
-                  target(actual).not[matcher](expected)
-                )
-            }
+          get (_, matcher) {
+            return (expectedArgs) =>
+              createExpectCaller({
+                actualTable,
+                expectedArgs,
+                propertyChains: [
+                  'not',
+                  matcher
+                ]
+              })
           }
         })
       }
 
-      return (expectedArgs) => {
-        actualTable
-          .map((it, index) =>
-            [it, expectedArgs[index]]
-          )
-          .find(([actual, expected]) =>
-            target(actual)[propertyName](expected)
-          )
-      }
+      return (expectedArgs) =>
+        createExpectCaller({
+          actualTable,
+          expectedArgs,
+          propertyChains: [propertyName]
+        })
     }
   })
+}
+
+/**
+ * Create expect caller.
+ *
+ * @param {{
+ *   actualTable: Array<*>,
+ *   expectedArgs: Array<*>,
+ *   propertyChains: Array<string>,
+ * }} params
+ * @returns {Array<*>} - Callers.
+ */
+function createExpectCaller ({
+  actualTable,
+  expectedArgs,
+  propertyChains,
+}) {
+  return actualTable
+    .map((it, index) =>
+      [it, expectedArgs[index]]
+    )
+    .map(([actual, expected]) =>
+      propertyChains.reduce(
+        (accumulator, it) => accumulator[it],
+        expect(actual)
+      )(expected)
+    )
 }

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -13,10 +13,10 @@ module.exports.setup = function () {
         return expectProxyCreators[propertyName](actualTable)
       }
 
-      return (expectedArgs) =>
+      return (expectedValues) =>
         createExpectCaller({
           actualTable,
-          expectedArgs,
+          expectedValues,
           propertyChains: [propertyName]
         })
     }
@@ -27,10 +27,10 @@ module.exports.setup = function () {
 const expectProxyCreators = {
   not: (actualTable) => new Proxy(expect, {
     get (_, matcher) {
-      return (expectedArgs) =>
+      return (expectedValues) =>
         createExpectCaller({
           actualTable,
-          expectedArgs,
+          expectedValues,
           propertyChains: [
             'not',
             matcher
@@ -53,19 +53,19 @@ const expectProxyCreators = {
  *
  * @param {{
  *   actualTable: Array<*>,
- *   expectedArgs: Array<*>,
+ *   expectedValues: Array<*>,
  *   propertyChains: Array<string>,
  * }} params
  * @returns {Array<*>} - Callers.
  */
 function createExpectCaller ({
   actualTable,
-  expectedArgs,
+  expectedValues,
   propertyChains,
 }) {
   return actualTable
     .map((it, index) =>
-      [it, expectedArgs[index]]
+      [it, expectedValues[index]]
     )
     .map(([actual, expected]) =>
       propertyChains.reduce(
@@ -93,10 +93,10 @@ function createExpectProxyAsPromise ({
       if (matcher === 'not') {
         return new Proxy(expect, {
           get (_, matcher) {
-            return (expectedArgs) => Promise.allSettled(
+            return (expectedValues) => Promise.allSettled(
               createExpectCaller({
                 actualTable,
-                expectedArgs,
+                expectedValues,
                 propertyChains: [
                   promiseMethod,
                   'not',
@@ -108,10 +108,10 @@ function createExpectProxyAsPromise ({
         })
       }
 
-      return (expectedArgs) => Promise.allSettled(
+      return (expectedValues) => Promise.allSettled(
         createExpectCaller({
           actualTable,
-          expectedArgs,
+          expectedValues,
           propertyChains: [
             promiseMethod,
             matcher

--- a/tests/__tests__/not/toBe.js
+++ b/tests/__tests__/not/toBe.js
@@ -14,9 +14,9 @@ describe('expect.each', () => {
       0,
       100,
     ]
-    const expectedTable = Array(actualValues.length).fill(-1000)
+    const expectedValues = Array(actualValues.length).fill(-1000)
 
     // @ts-ignore
-    expect.each(actualValues).not.toBe(expectedTable)
+    expect.each(actualValues).not.toBe(expectedValues)
   })
 })

--- a/tests/__tests__/not/toBe.js
+++ b/tests/__tests__/not/toBe.js
@@ -5,7 +5,7 @@ require('../../../lib/setup').setup()
 
 describe('expect.each', () => {
   test('#toBe()', () => {
-    const actualTable = [
+    const actualValues = [
       undefined,
       null,
       false,
@@ -14,9 +14,9 @@ describe('expect.each', () => {
       0,
       100,
     ]
-    const expectedTable = Array(actualTable.length).fill(-1000)
+    const expectedTable = Array(actualValues.length).fill(-1000)
 
     // @ts-ignore
-    expect.each(actualTable).not.toBe(expectedTable)
+    expect.each(actualValues).not.toBe(expectedTable)
   })
 })

--- a/tests/__tests__/rejects/not.toBe.js
+++ b/tests/__tests__/rejects/not.toBe.js
@@ -1,0 +1,30 @@
+// @ts-check
+'use strict'
+
+require('../../../lib/setup').setup()
+
+describe('expect.each', () => {
+  describe('#rejects', () => {
+    test('#toBe()', async () => {
+      const actualTable = [
+        'first error',
+        'second error',
+        'third error',
+        'fourth error',
+      ]
+      const actualErrors = actualTable.map(it => Error(it))
+      const expectedTable = Array(actualTable.length).fill('unknown error')
+
+      await expect(Promise.reject(actualErrors[0]))
+        .rejects
+        .not
+        .toThrowError(expectedTable[0])
+
+      // @ts-ignore
+      await expect.each(actualErrors.map(it => Promise.reject(it)))
+        .rejects
+        .not
+        .toThrowError(expectedTable)
+    })
+  })
+})

--- a/tests/__tests__/rejects/not.toBe.js
+++ b/tests/__tests__/rejects/not.toBe.js
@@ -13,18 +13,18 @@ describe('expect.each', () => {
         'fourth error',
       ]
       const actualErrors = actualValues.map(it => Error(it))
-      const expectedTable = Array(actualValues.length).fill('unknown error')
+      const expectedValues = Array(actualValues.length).fill('unknown error')
 
       await expect(Promise.reject(actualErrors[0]))
         .rejects
         .not
-        .toThrowError(expectedTable[0])
+        .toThrowError(expectedValues[0])
 
       // @ts-ignore
       await expect.each(actualErrors.map(it => Promise.reject(it)))
         .rejects
         .not
-        .toThrowError(expectedTable)
+        .toThrowError(expectedValues)
     })
   })
 })

--- a/tests/__tests__/rejects/not.toBe.js
+++ b/tests/__tests__/rejects/not.toBe.js
@@ -6,14 +6,14 @@ require('../../../lib/setup').setup()
 describe('expect.each', () => {
   describe('#rejects', () => {
     test('#toBe()', async () => {
-      const actualTable = [
+      const actualValues = [
         'first error',
         'second error',
         'third error',
         'fourth error',
       ]
-      const actualErrors = actualTable.map(it => Error(it))
-      const expectedTable = Array(actualTable.length).fill('unknown error')
+      const actualErrors = actualValues.map(it => Error(it))
+      const expectedTable = Array(actualValues.length).fill('unknown error')
 
       await expect(Promise.reject(actualErrors[0]))
         .rejects

--- a/tests/__tests__/rejects/toBe.js
+++ b/tests/__tests__/rejects/toBe.js
@@ -13,16 +13,16 @@ describe('expect.each', () => {
         'fourth error',
       ]
       const actualErrors = actualValues.map(it => Error(it))
-      const expectedTable = actualValues
+      const expectedValues = actualValues
 
       await expect(Promise.reject(actualErrors[0]))
         .rejects
-        .toThrowError(expectedTable[0])
+        .toThrowError(expectedValues[0])
 
       // @ts-ignore
       await expect.each(actualErrors.map(it => Promise.reject(it)))
         .rejects
-        .toThrowError(expectedTable)
+        .toThrowError(expectedValues)
     })
   })
 })

--- a/tests/__tests__/rejects/toBe.js
+++ b/tests/__tests__/rejects/toBe.js
@@ -1,0 +1,28 @@
+// @ts-check
+'use strict'
+
+require('../../../lib/setup').setup()
+
+describe('expect.each', () => {
+  describe('#rejects', () => {
+    test('#toBe()', async () => {
+      const actualTable = [
+        'first error',
+        'second error',
+        'third error',
+        'fourth error',
+      ]
+      const actualErrors = actualTable.map(it => Error(it))
+      const expectedTable = actualTable
+
+      await expect(Promise.reject(actualErrors[0]))
+        .rejects
+        .toThrowError(expectedTable[0])
+
+      // @ts-ignore
+      await expect.each(actualErrors.map(it => Promise.reject(it)))
+        .rejects
+        .toThrowError(expectedTable)
+    })
+  })
+})

--- a/tests/__tests__/rejects/toBe.js
+++ b/tests/__tests__/rejects/toBe.js
@@ -6,14 +6,14 @@ require('../../../lib/setup').setup()
 describe('expect.each', () => {
   describe('#rejects', () => {
     test('#toBe()', async () => {
-      const actualTable = [
+      const actualValues = [
         'first error',
         'second error',
         'third error',
         'fourth error',
       ]
-      const actualErrors = actualTable.map(it => Error(it))
-      const expectedTable = actualTable
+      const actualErrors = actualValues.map(it => Error(it))
+      const expectedTable = actualValues
 
       await expect(Promise.reject(actualErrors[0]))
         .rejects

--- a/tests/__tests__/resolves/not.toBe.js
+++ b/tests/__tests__/resolves/not.toBe.js
@@ -1,0 +1,34 @@
+// @ts-check
+'use strict'
+
+require('../../../lib/setup').setup()
+
+describe('expect.each', () => {
+  describe('#resolves', () => {
+    test('#toBe()', async () => {
+      const actualTable = [
+        undefined,
+        null,
+        false,
+        true,
+        'string',
+        0,
+        100,
+      ]
+      const expectedTable = Array(actualTable.length).fill(-1000)
+
+      await expect(Promise.resolve(actualTable[0]))
+        .resolves
+        .not
+        .toBe(expectedTable[0])
+
+      // @ts-ignore
+      await expect.each(
+        actualTable.map(it => Promise.resolve(it))
+      )
+        .resolves
+        .not
+        .toBe(expectedTable)
+    })
+  })
+})

--- a/tests/__tests__/resolves/not.toBe.js
+++ b/tests/__tests__/resolves/not.toBe.js
@@ -6,7 +6,7 @@ require('../../../lib/setup').setup()
 describe('expect.each', () => {
   describe('#resolves', () => {
     test('#toBe()', async () => {
-      const actualTable = [
+      const actualValues = [
         undefined,
         null,
         false,
@@ -15,16 +15,16 @@ describe('expect.each', () => {
         0,
         100,
       ]
-      const expectedTable = Array(actualTable.length).fill(-1000)
+      const expectedTable = Array(actualValues.length).fill(-1000)
 
-      await expect(Promise.resolve(actualTable[0]))
+      await expect(Promise.resolve(actualValues[0]))
         .resolves
         .not
         .toBe(expectedTable[0])
 
       // @ts-ignore
       await expect.each(
-        actualTable.map(it => Promise.resolve(it))
+        actualValues.map(it => Promise.resolve(it))
       )
         .resolves
         .not

--- a/tests/__tests__/resolves/not.toBe.js
+++ b/tests/__tests__/resolves/not.toBe.js
@@ -15,12 +15,12 @@ describe('expect.each', () => {
         0,
         100,
       ]
-      const expectedTable = Array(actualValues.length).fill(-1000)
+      const expectedValues = Array(actualValues.length).fill(-1000)
 
       await expect(Promise.resolve(actualValues[0]))
         .resolves
         .not
-        .toBe(expectedTable[0])
+        .toBe(expectedValues[0])
 
       // @ts-ignore
       await expect.each(
@@ -28,7 +28,7 @@ describe('expect.each', () => {
       )
         .resolves
         .not
-        .toBe(expectedTable)
+        .toBe(expectedValues)
     })
   })
 })

--- a/tests/__tests__/resolves/toBe.js
+++ b/tests/__tests__/resolves/toBe.js
@@ -1,0 +1,32 @@
+// @ts-check
+'use strict'
+
+require('../../../lib/setup').setup()
+
+describe('expect.each', () => {
+  describe('#resolves', () => {
+    test('#toBe()', async () => {
+      const actualTable = [
+        undefined,
+        null,
+        false,
+        true,
+        'string',
+        0,
+        100,
+      ]
+      const expectedTable = actualTable
+
+      await expect(Promise.resolve(actualTable[0]))
+        .resolves
+        .toBe(expectedTable[0])
+
+      // @ts-ignore
+      await expect.each(
+        actualTable.map(it => Promise.resolve(it))
+      )
+        .resolves
+        .toBe(expectedTable)
+    })
+  })
+})

--- a/tests/__tests__/resolves/toBe.js
+++ b/tests/__tests__/resolves/toBe.js
@@ -6,7 +6,7 @@ require('../../../lib/setup').setup()
 describe('expect.each', () => {
   describe('#resolves', () => {
     test('#toBe()', async () => {
-      const actualTable = [
+      const actualValues = [
         undefined,
         null,
         false,
@@ -15,15 +15,15 @@ describe('expect.each', () => {
         0,
         100,
       ]
-      const expectedTable = actualTable
+      const expectedTable = actualValues
 
-      await expect(Promise.resolve(actualTable[0]))
+      await expect(Promise.resolve(actualValues[0]))
         .resolves
         .toBe(expectedTable[0])
 
       // @ts-ignore
       await expect.each(
-        actualTable.map(it => Promise.resolve(it))
+        actualValues.map(it => Promise.resolve(it))
       )
         .resolves
         .toBe(expectedTable)

--- a/tests/__tests__/resolves/toBe.js
+++ b/tests/__tests__/resolves/toBe.js
@@ -15,18 +15,18 @@ describe('expect.each', () => {
         0,
         100,
       ]
-      const expectedTable = actualValues
+      const expectedValues = actualValues
 
       await expect(Promise.resolve(actualValues[0]))
         .resolves
-        .toBe(expectedTable[0])
+        .toBe(expectedValues[0])
 
       // @ts-ignore
       await expect.each(
         actualValues.map(it => Promise.resolve(it))
       )
         .resolves
-        .toBe(expectedTable)
+        .toBe(expectedValues)
     })
   })
 })

--- a/tests/__tests__/straights/toBe.js
+++ b/tests/__tests__/straights/toBe.js
@@ -14,9 +14,9 @@ describe('expect.each', () => {
       0,
       100,
     ]
-    const expectedTable = actualValues
+    const expectedValues = actualValues
 
     // @ts-ignore
-    expect.each(actualValues).toBe(expectedTable)
+    expect.each(actualValues).toBe(expectedValues)
   })
 })

--- a/tests/__tests__/straights/toBe.js
+++ b/tests/__tests__/straights/toBe.js
@@ -5,7 +5,7 @@ require('../../../lib/setup').setup()
 
 describe('expect.each', () => {
   test('#toBe()', () => {
-    const actualTable = [
+    const actualValues = [
       undefined,
       null,
       false,
@@ -14,9 +14,9 @@ describe('expect.each', () => {
       0,
       100,
     ]
-    const expectedTable = actualTable
+    const expectedTable = actualValues
 
     // @ts-ignore
-    expect.each(actualTable).toBe(expectedTable)
+    expect.each(actualValues).toBe(expectedTable)
   })
 })


### PR DESCRIPTION
## Why

* See #7 

## How

* Implement `expect.each().resolves` and `.rejects`.

## Note

* This is just prototype of 'expect.each()'.

* When it is OK, must add more test cases for other matcher of Jest.