### PR TITLE
🐛 Fix multiple parameters of matcher (for prototype)

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -63,6 +63,12 @@ function createExpectCaller ({
   expectedValues,
   propertyChains,
 }) {
+  const normalizedExpectedValues = expectedValues.map(it =>
+    Array.isArray(it)
+      ? it
+      : [it]
+  )
+
   return actualValues
     .map(value =>
       propertyChains.reduce(
@@ -71,7 +77,7 @@ function createExpectCaller ({
       )
     )
     .map((matcher, index) =>
-      matcher(expectedValues[index])
+      matcher(...normalizedExpectedValues[index])
     )
 }
 

--- a/tests/__tests__/not/toBeCloseTo.js
+++ b/tests/__tests__/not/toBeCloseTo.js
@@ -5,27 +5,27 @@ require('../../../lib/setup').setup()
 
 describe('expect.each', () => {
   test('#toBeCloseTo()', () => {
-    const actualTable = [
+    const actualValues = [
       0.1 + 0.2,
     ]
-    const expectedTable = [
+    const expectedValues = [
       0.3,
     ]
 
-    expect(actualTable[0])
+    expect(actualValues[0])
       .toBe(0.30000000000000004)
-    expect(actualTable[0]).not // <---- !!!!
-      .toBe(expectedTable[0])
+    expect(actualValues[0]).not // <---- !!!!
+      .toBe(expectedValues[0])
 
-    expect(actualTable[0])
-      .toBeCloseTo(expectedTable[0], 15)
-    expect(actualTable[0]).not // <---- !!!!
-      .toBeCloseTo(expectedTable[0], 16)
+    expect(actualValues[0])
+      .toBeCloseTo(expectedValues[0], 15)
+    expect(actualValues[0]).not // <---- !!!!
+      .toBeCloseTo(expectedValues[0], 16)
 
     // @ts-ignore
-    expect.each(actualTable).not // <---- !!!!
+    expect.each(actualValues).not // <---- !!!!
       .toBeCloseTo(
-        expectedTable.map(it => [it, 16])
+        expectedValues.map(it => [it, 16])
       )
   })
 })

--- a/tests/__tests__/not/toBeCloseTo.js
+++ b/tests/__tests__/not/toBeCloseTo.js
@@ -1,0 +1,31 @@
+// @ts-check
+'use strict'
+
+require('../../../lib/setup').setup()
+
+describe('expect.each', () => {
+  test('#toBeCloseTo()', () => {
+    const actualTable = [
+      0.1 + 0.2,
+    ]
+    const expectedTable = [
+      0.3,
+    ]
+
+    expect(actualTable[0])
+      .toBe(0.30000000000000004)
+    expect(actualTable[0]).not // <---- !!!!
+      .toBe(expectedTable[0])
+
+    expect(actualTable[0])
+      .toBeCloseTo(expectedTable[0], 15)
+    expect(actualTable[0]).not // <---- !!!!
+      .toBeCloseTo(expectedTable[0], 16)
+
+    // @ts-ignore
+    expect.each(actualTable).not // <---- !!!!
+      .toBeCloseTo(
+        expectedTable.map(it => [it, 16])
+      )
+  })
+})

--- a/tests/__tests__/straights/toBeCloseTo.js
+++ b/tests/__tests__/straights/toBeCloseTo.js
@@ -5,27 +5,27 @@ require('../../../lib/setup').setup()
 
 describe('expect.each', () => {
   test('#toBeCloseTo()', () => {
-    const actualTable = [
+    const actualValues = [
       0.1 + 0.2,
     ]
-    const expectedTable = [
+    const expectedValues = [
       0.3,
     ]
 
-    expect(actualTable[0])
+    expect(actualValues[0])
       .toBe(0.30000000000000004)
-    expect(actualTable[0]).not // <---- !!!!
-      .toBe(expectedTable[0])
+    expect(actualValues[0]).not // <---- !!!!
+      .toBe(expectedValues[0])
 
-    expect(actualTable[0])
-      .toBeCloseTo(expectedTable[0], 15)
-    expect(actualTable[0]).not // <---- !!!!
-      .toBeCloseTo(expectedTable[0], 16)
+    expect(actualValues[0])
+      .toBeCloseTo(expectedValues[0], 15)
+    expect(actualValues[0]).not // <---- !!!!
+      .toBeCloseTo(expectedValues[0], 16)
 
     // @ts-ignore
-    expect.each(actualTable)
+    expect.each(actualValues)
       .toBeCloseTo(
-        expectedTable.map(it => [it, 15])
+        expectedValues.map(it => [it, 15])
       )
   })
 })

--- a/tests/__tests__/straights/toBeCloseTo.js
+++ b/tests/__tests__/straights/toBeCloseTo.js
@@ -1,0 +1,31 @@
+// @ts-check
+'use strict'
+
+require('../../../lib/setup').setup()
+
+describe('expect.each', () => {
+  test('#toBeCloseTo()', () => {
+    const actualTable = [
+      0.1 + 0.2,
+    ]
+    const expectedTable = [
+      0.3,
+    ]
+
+    expect(actualTable[0])
+      .toBe(0.30000000000000004)
+    expect(actualTable[0]).not // <---- !!!!
+      .toBe(expectedTable[0])
+
+    expect(actualTable[0])
+      .toBeCloseTo(expectedTable[0], 15)
+    expect(actualTable[0]).not // <---- !!!!
+      .toBeCloseTo(expectedTable[0], 16)
+
+    // @ts-ignore
+    expect.each(actualTable)
+      .toBeCloseTo(
+        expectedTable.map(it => [it, 15])
+      )
+  })
+})


### PR DESCRIPTION
## Why

* See #11

## How

* Fix to handle expected values in `createExpectCaller()`.
