### PR TITLE
🧪 Kick out typo `Promise.rejects()` from test for `expect.each()` concerning `.toBeNull()`

### DIFF
--- a/tests/__tests__/expect.each/toBeNull.js
+++ b/tests/__tests__/expect.each/toBeNull.js
@@ -860,7 +860,7 @@ describe('expect.each()', () => {
         test.each(lackedCases)('length: $expectedValues.length', async ({ expectedValues }) => {
           await expect(() =>
             // @ts-expect-error
-            expect.each(actualValues.map(it => () => Promise.rejects(it)))
+            expect.each(actualValues.map(it => () => Promise.reject(it)))
               .rejects
               .toBeNull.each(expectedValues)
           )
@@ -892,7 +892,7 @@ describe('expect.each()', () => {
         test.each(excessCases)('length: $expectedValues.length', async ({ expectedValues }) => {
           await expect(() =>
             // @ts-expect-error
-            expect.each(actualValues.map(it => () => Promise.rejects(it)))
+            expect.each(actualValues.map(it => () => Promise.reject(it)))
               .rejects
               .toBeNull.each(expectedValues)
           )
@@ -917,7 +917,7 @@ describe('expect.each()', () => {
       test.each(cases)('actual values: $actualValues', async ({ actualValues, expectedValues }) => {
         await expect(() =>
           // @ts-expect-error
-          expect.each(actualValues.map(it => () => Promise.rejects(it)))
+          expect.each(actualValues.map(it => () => Promise.reject(it)))
             .rejects
             .toBeNull.each(expectedValues)
         )


### PR DESCRIPTION
## Why

* Close #82