### PR TITLE
✅️ Kick out `@ts-expect-error` annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ test('all promises should reject with error', async () => {
     Promise.reject(new Error('failed'))
   ]
 
-  // @ts-expect-error
   await expect.each(promises)
     .rejects
     .toThrow('failed')
@@ -108,13 +107,7 @@ test('no value should be 999', () => {
 
 # TypeScript Support
 
-When using TypeScript or type checking in VS Code, add `// @ts-expect-error` before `expect.each()` calls to suppress type errors:
-
-```typescript
-// @ts-expect-error
-expect.each(actualValues)
-  .toBe(expectedValue)
-```
+When using TypeScript or type checking in VS Code, import `types/jest-expect.each.d.ts` in your package.
 
 # Error Handling
 

--- a/lib/setup-expect-each.js
+++ b/lib/setup-expect-each.js
@@ -9,11 +9,10 @@ module.exports.setupExpectEach = function () {
   /**
    * Extend each() to expect of Jest method.
    *
-   * @param {Array<*>} actualValues - Test table.
-   * @returns {Proxy<expect>} - Proxy of expect.
+   * @param {Parameters<jest.Expect['each']>[0]} actualValues - Test table.
+   * @returns {ReturnType<jest.Expect['each']>} - Proxy of expect.
    */
-  // @ts-expect-error
-  expect.each = (actualValues) => new Proxy(expect, {
+  expect.each = (actualValues) => new Proxy(/** @type {*} */ (expect), {
     /**
      * get() for Proxy sink.
      *

--- a/lib/setup-expect-each.js
+++ b/lib/setup-expect-each.js
@@ -188,14 +188,13 @@ function dispatchMatcherWithPluralExpectedValues ({
  *   actualValues: Array<*>,
  *   promiseMethod: string,
  * }} params
- * @returns {Proxy} - Proxy for expect methods.
+ * @returns {Proxy<ReturnType<jest.Expect['each']>>} - Proxy for expect methods.
  */
 function createExpectProxyAsPromise ({
   actualValues,
   promiseMethod,
 }) {
-  // @ts-expect-error
-  return new Proxy(expect, {
+  return new Proxy(/** @type {*} */ (expect), {
     /**
      * get() for Proxy sink.
      *

--- a/tests/__tests__/expect.each/toBe.js
+++ b/tests/__tests__/expect.each/toBe.js
@@ -33,7 +33,6 @@ describe('expect.each()', () => {
 
       describe('matched', () => {
         test.each(lengthCases)('length: $values.length', ({ values }) => {
-          // @ts-expect-error
           expect.each(values)
             .toBe(tally)
         })
@@ -44,7 +43,6 @@ describe('expect.each()', () => {
 
         test.each(lengthCases)('length: $values.length', ({ values }) => {
           expect(() =>
-            // @ts-expect-error
             expect.each(values)
               .toBe(unmatchedValue)
           )
@@ -90,7 +88,6 @@ describe('expect.each()', () => {
         const unmatchedValue = Symbol('unmatchedValue')
 
         test.each(lengthCases)('length: $values.length', ({ values }) => {
-          // @ts-expect-error
           expect.each(values)
             .not
             .toBe(unmatchedValue)
@@ -100,7 +97,6 @@ describe('expect.each()', () => {
       describe('unmatched to throw', () => {
         test.each(lengthCases)('length: $values.length', ({ values }) => {
           expect(() =>
-            // @ts-expect-error
             expect.each(values)
               .not
               .toBe(tally)
@@ -160,7 +156,6 @@ describe('expect.each()', () => {
         ]
 
         test.each(lengthCases)('length: $values.length', async ({ values }) => {
-          // @ts-expect-error
           await expect.each(values)
             .resolves
             .toBe(tally)
@@ -193,7 +188,6 @@ describe('expect.each()', () => {
 
         test.each(lengthCases)('length: $values.length', async ({ values }) => {
           await expect(
-            // @ts-expect-error
             expect.each(values)
               .resolves
               .toBe(unmatchedValue)
@@ -256,7 +250,6 @@ describe('expect.each()', () => {
         ]
 
         test.each(lengthCases)('length: $values.length', async ({ values }) => {
-          // @ts-expect-error
           await expect.each(values)
             .resolves
             .not
@@ -288,7 +281,6 @@ describe('expect.each()', () => {
 
         test.each(lengthCases)('length: $values.length', async ({ values }) => {
           await expect(
-            // @ts-expect-error
             expect.each(values)
               .resolves
               .not
@@ -350,7 +342,6 @@ describe('expect.each()', () => {
         ]
 
         test.each(lengthCases)('length: $values().length', async ({ values }) => {
-          // @ts-expect-error
           await expect.each(values())
             .rejects
             .toBe(tally)
@@ -383,7 +374,6 @@ describe('expect.each()', () => {
 
         test.each(lengthCases)('length: $values().length', async ({ values }) => {
           await expect(
-            // @ts-expect-error
             expect.each(values())
               .rejects
               .toBe(unmatchedValue)
@@ -446,7 +436,6 @@ describe('expect.each()', () => {
         ]
 
         test.each(lengthCases)('length: $values().length', async ({ values }) => {
-          // @ts-expect-error
           await expect.each(values())
             .rejects
             .not
@@ -478,7 +467,6 @@ describe('expect.each()', () => {
 
         test.each(lengthCases)('length: $values().length', async ({ values }) => {
           await expect(
-            // @ts-expect-error
             expect.each(values())
               .rejects
               .not
@@ -528,7 +516,6 @@ describe('expect.each()', () => {
       describe.each(cases)('actual values: $actualValues', ({ actualValues, lackedCases }) => {
         test.each(lackedCases)('expected values: $expectedValues', ({ expectedValues }) => {
           expect(() =>
-            // @ts-expect-error
             expect.each(actualValues)
               .toBe.each(expectedValues)
           )
@@ -568,7 +555,6 @@ describe('expect.each()', () => {
       describe.each(cases)('actual values: $actualValues', ({ actualValues, excessCases }) => {
         test.each(excessCases)('expected values: $expectedValues', ({ expectedValues }) => {
           expect(() =>
-            // @ts-expect-error
             expect.each(actualValues)
               .toBe.each(expectedValues)
           )
@@ -596,7 +582,6 @@ describe('expect.each()', () => {
       ]
 
       test.each(cases)('actual values: $actualValues', ({ actualValues, expectedValues }) => {
-        // @ts-expect-error
         expect.each(actualValues)
           .toBe.each(expectedValues)
       })
@@ -680,7 +665,6 @@ describe('expect.each()', () => {
       describe.each(cases)('actual values: $actualValues', ({ actualValues, unmatchedCases }) => {
         test.each(unmatchedCases)('expected values: $expectedValues', ({ expectedValues }) => {
           expect(() =>
-            // @ts-expect-error
             expect.each(actualValues)
               .toBe.each(expectedValues)
           )
@@ -725,7 +709,6 @@ describe('expect.each()', () => {
       describe.each(cases)('actual values: $actualValues', ({ actualValues, lackedCases }) => {
         test.each(lackedCases)('expected values: $expectedValues', ({ expectedValues }) => {
           expect(() =>
-            // @ts-expect-error
             expect.each(actualValues)
               .not
               .toBe.each(expectedValues)
@@ -766,7 +749,6 @@ describe('expect.each()', () => {
       describe.each(cases)('actual values: $actualValues', ({ actualValues, excessCases }) => {
         test.each(excessCases)('expected values: $expectedValues', ({ expectedValues }) => {
           expect(() =>
-            // @ts-expect-error
             expect.each(actualValues)
               .not
               .toBe.each(expectedValues)
@@ -845,7 +827,6 @@ describe('expect.each()', () => {
 
       describe.each(cases)('actual values: $actualValues', ({ actualValues, unmatchedCases }) => {
         test.each(unmatchedCases)('expected values: $expectedValues', ({ expectedValues }) => {
-          // @ts-expect-error
           expect.each(actualValues)
             .not
             .toBe.each(expectedValues)
@@ -873,7 +854,6 @@ describe('expect.each()', () => {
 
       test.each(cases)('actual values: $actualValues', ({ actualValues, expectedValues }) => {
         expect(() =>
-          // @ts-expect-error
           expect.each(actualValues)
             .not
             .toBe.each(expectedValues)
@@ -918,7 +898,6 @@ describe('expect.each()', () => {
       describe.each(cases)('actual values: $actualValues', ({ actualValues, lackedCases }) => {
         test.each(lackedCases)('expected values: $expectedValues', async ({ expectedValues }) => {
           await expect(() =>
-            // @ts-expect-error
             expect.each(actualValues.map(it => Promise.resolve(it)))
               .resolves
               .toBe.each(expectedValues)
@@ -960,7 +939,6 @@ describe('expect.each()', () => {
       describe.each(cases)('actual values: $actualValues', ({ actualValues, excessCases }) => {
         test.each(excessCases)('expected values: $expectedValues', async ({ expectedValues }) => {
           await expect(() =>
-            // @ts-expect-error
             expect.each(actualValues.map(it => Promise.resolve(it)))
               .resolves
               .toBe.each(expectedValues)
@@ -990,7 +968,6 @@ describe('expect.each()', () => {
       ]
 
       test.each(cases)('actual values: $actualValues', async ({ actualValues, expectedValues }) => {
-        // @ts-expect-error
         await expect.each(actualValues.map(it => Promise.resolve(it)))
           .resolves
           .toBe.each(expectedValues)
@@ -1075,7 +1052,6 @@ describe('expect.each()', () => {
       describe.each(cases)('actual values: $actualValues', ({ actualValues, unmatchedCases }) => {
         test.each(unmatchedCases)('expected values: $expectedValues', async ({ expectedValues }) => {
           await expect(() =>
-            // @ts-expect-error
             expect.each(actualValues.map(it => Promise.resolve(it)))
               .resolves
               .toBe.each(expectedValues)
@@ -1122,7 +1098,6 @@ describe('expect.each()', () => {
       describe.each(cases)('actual values: $actualValues', ({ actualValues, lackedCases }) => {
         test.each(lackedCases)('expected values: $expectedValues', async ({ expectedValues }) => {
           await expect(() =>
-            // @ts-expect-error
             expect.each(actualValues.map(it => Promise.resolve(it)))
               .resolves
               .not
@@ -1165,7 +1140,6 @@ describe('expect.each()', () => {
       describe.each(cases)('actual values: $actualValues', ({ actualValues, excessCases }) => {
         test.each(excessCases)('expected values: $expectedValues', async ({ expectedValues }) => {
           await expect(() =>
-            // @ts-expect-error
             expect.each(actualValues.map(it => Promise.resolve(it)))
               .resolves
               .not
@@ -1246,7 +1220,6 @@ describe('expect.each()', () => {
 
       describe.each(cases)('actual values: $actualValues', ({ actualValues, matchedCases }) => {
         test.each(matchedCases)('expected values: $expectedValues', async ({ expectedValues }) => {
-          // @ts-expect-error
           await expect.each(actualValues.map(it => Promise.resolve(it)))
             .resolves
             .not
@@ -1275,7 +1248,6 @@ describe('expect.each()', () => {
 
       test.each(cases)('actual values: $actualValues', async ({ actualValues, expectedValues }) => {
         await expect(() =>
-          // @ts-expect-error
           expect.each(actualValues.map(it => Promise.resolve(it)))
             .resolves
             .not
@@ -1322,7 +1294,6 @@ describe('expect.each()', () => {
       describe.each(cases)('actual values: $actualValues', ({ actualValues, lackedCases }) => {
         test.each(lackedCases)('expected values: $expectedValues', async ({ expectedValues }) => {
           await expect(() =>
-            // @ts-expect-error
             expect.each(actualValues.map(it => () => Promise.reject(it)))
               .rejects
               .toBe.each(expectedValues)
@@ -1364,7 +1335,6 @@ describe('expect.each()', () => {
       describe.each(cases)('actual values: $actualValues', ({ actualValues, excessCases }) => {
         test.each(excessCases)('expected values: $expectedValues', async ({ expectedValues }) => {
           await expect(() =>
-            // @ts-expect-error
             expect.each(actualValues.map(it => () => Promise.reject(it)))
               .rejects
               .toBe.each(expectedValues)
@@ -1394,7 +1364,6 @@ describe('expect.each()', () => {
       ]
 
       test.each(cases)('actual values: $actualValues', async ({ actualValues, expectedValues }) => {
-        // @ts-expect-error
         await expect.each(actualValues.map(it => () => Promise.reject(it)))
           .rejects
           .toBe.each(expectedValues)
@@ -1479,7 +1448,6 @@ describe('expect.each()', () => {
       describe.each(cases)('actual values: $actualValues', ({ actualValues, unmatchedCases }) => {
         test.each(unmatchedCases)('expected values: $expectedValues', async ({ expectedValues }) => {
           await expect(() =>
-            // @ts-expect-error
             expect.each(actualValues.map(it => () => Promise.reject(it)))
               .rejects
               .toBe.each(expectedValues)
@@ -1526,7 +1494,6 @@ describe('expect.each()', () => {
       describe.each(cases)('actual values: $actualValues', ({ actualValues, lackedCases }) => {
         test.each(lackedCases)('expected values: $expectedValues', async ({ expectedValues }) => {
           await expect(() =>
-            // @ts-expect-error
             expect.each(actualValues.map(it => () => Promise.reject(it)))
               .rejects
               .not
@@ -1569,7 +1536,6 @@ describe('expect.each()', () => {
       describe.each(cases)('actual values: $actualValues', ({ actualValues, excessCases }) => {
         test.each(excessCases)('expected values: $expectedValues', async ({ expectedValues }) => {
           await expect(() =>
-            // @ts-expect-error
             expect.each(actualValues.map(it => () => Promise.reject(it)))
               .rejects
               .not
@@ -1650,7 +1616,6 @@ describe('expect.each()', () => {
 
       describe.each(cases)('actual values: $actualValues', ({ actualValues, matchedCases }) => {
         test.each(matchedCases)('expected values: $expectedValues', async ({ expectedValues }) => {
-          // @ts-expect-error
           await expect.each(actualValues.map(it => () => Promise.reject(it)))
             .rejects
             .not
@@ -1679,7 +1644,6 @@ describe('expect.each()', () => {
 
       test.each(cases)('actual values: $actualValues', async ({ actualValues, expectedValues }) => {
         await expect(() =>
-          // @ts-expect-error
           expect.each(actualValues.map(it => () => Promise.reject(it)))
             .rejects
             .not

--- a/tests/__tests__/expect.each/toBeCloseTo.js
+++ b/tests/__tests__/expect.each/toBeCloseTo.js
@@ -2,6 +2,17 @@
 
 describe('expect.each()', () => {
   describe('.toBeCloseTo()', () => {
+    /**
+     * @type {Array<{
+     *   values: Array<number>
+     *   matchedExpectedCases: Array<{
+     *     expected: [number, number]
+     *   }>
+     *   unmatchedExpectedCases: Array<{
+     *     expected: [number, number]
+     *   }>
+     * }>}
+     */
     const cases = [
       {
         values: [
@@ -40,7 +51,6 @@ describe('expect.each()', () => {
     describe.each(cases)('values: $values', ({ values, matchedExpectedCases, unmatchedExpectedCases }) => {
       describe('matched', () => {
         test.each(matchedExpectedCases)('expected: $expected', ({ expected }) => {
-          // @ts-expect-error
           expect.each(values)
             .toBeCloseTo(...expected)
         })
@@ -49,7 +59,6 @@ describe('expect.each()', () => {
       describe('unmatched to throw', () => {
         test.each(unmatchedExpectedCases)('expected: $expected', ({ expected }) => {
           expect(() =>
-            // @ts-expect-error
             expect.each(values)
               .toBeCloseTo(...expected)
           )
@@ -62,6 +71,17 @@ describe('expect.each()', () => {
 
 describe('expect.each()', () => {
   describe('.not.toBeCloseTo()', () => {
+    /**
+     * @type {Array<{
+     *   values: Array<number>
+     *   matchedExpectedCases: Array<{
+     *     expected: [number, number]
+     *   }>
+     *   unmatchedExpectedCases: Array<{
+     *     expected: [number, number]
+     *   }>
+     * }>}
+     */
     const cases = [
       {
         values: [
@@ -100,7 +120,6 @@ describe('expect.each()', () => {
     describe.each(cases)('values: $values', ({ values, matchedExpectedCases, unmatchedExpectedCases }) => {
       describe('matched', () => {
         test.each(matchedExpectedCases)('expected: $expected', ({ expected }) => {
-          // @ts-expect-error
           expect.each(values)
             .not
             .toBeCloseTo(...expected)
@@ -110,7 +129,6 @@ describe('expect.each()', () => {
       describe('unmatched to throw', () => {
         test.each(unmatchedExpectedCases)('expected: $expected', ({ expected }) => {
           expect(() =>
-            // @ts-expect-error
             expect.each(values)
               .not
               .toBeCloseTo(...expected)
@@ -124,6 +142,17 @@ describe('expect.each()', () => {
 
 describe('expect.each()', () => {
   describe('.resolves.toBeCloseTo()', () => {
+    /**
+     * @type {Array<{
+     *   values: Array<number>
+     *   matchedExpectedCases: Array<{
+     *     expected: [number, number]
+     *   }>
+     *   unmatchedExpectedCases: Array<{
+     *     expected: [number, number]
+     *   }>
+     * }>}
+     */
     const cases = [
       {
         values: [
@@ -162,7 +191,6 @@ describe('expect.each()', () => {
     describe.each(cases)('values: $values', ({ values, matchedExpectedCases, unmatchedExpectedCases }) => {
       describe('matched', () => {
         test.each(matchedExpectedCases)('expected: $expected', async ({ expected }) => {
-          // @ts-expect-error
           await expect.each(values.map(it => Promise.resolve(it)))
             .resolves
             .toBeCloseTo(...expected)
@@ -172,7 +200,6 @@ describe('expect.each()', () => {
       describe('unmatched to throw', () => {
         test.each(unmatchedExpectedCases)('expected: $expected', async ({ expected }) => {
           await expect(() =>
-            // @ts-expect-error
             expect.each(values.map(it => Promise.resolve(it)))
               .resolves
               .toBeCloseTo(...expected)
@@ -187,6 +214,17 @@ describe('expect.each()', () => {
 
 describe('expect.each()', () => {
   describe('.resolves.not.toBeCloseTo()', () => {
+    /**
+     * @type {Array<{
+     *   values: Array<number>
+     *   matchedExpectedCases: Array<{
+     *     expected: [number, number]
+     *   }>
+     *   unmatchedExpectedCases: Array<{
+     *     expected: [number, number]
+     *   }>
+     * }>}
+     */
     const cases = [
       {
         values: [
@@ -225,7 +263,6 @@ describe('expect.each()', () => {
     describe.each(cases)('values: $values', ({ values, matchedExpectedCases, unmatchedExpectedCases }) => {
       describe('matched', () => {
         test.each(matchedExpectedCases)('expected: $expected', async ({ expected }) => {
-          // @ts-expect-error
           await expect.each(values.map(it => Promise.resolve(it)))
             .resolves
             .not
@@ -236,7 +273,6 @@ describe('expect.each()', () => {
       describe('unmatched to throw', () => {
         test.each(unmatchedExpectedCases)('expected: $expected', async ({ expected }) => {
           await expect(() =>
-            // @ts-expect-error
             expect.each(values.map(it => Promise.resolve(it)))
               .resolves
               .not
@@ -252,6 +288,17 @@ describe('expect.each()', () => {
 
 describe('expect.each()', () => {
   describe('.rejects.toBeCloseTo()', () => {
+    /**
+     * @type {Array<{
+     *   values: Array<number>
+     *   matchedExpectedCases: Array<{
+     *     expected: [number, number]
+     *   }>
+     *   unmatchedExpectedCases: Array<{
+     *     expected: [number, number]
+     *   }>
+     * }>}
+     */
     const cases = [
       {
         values: [
@@ -290,7 +337,6 @@ describe('expect.each()', () => {
     describe.each(cases)('values: $values', ({ values, matchedExpectedCases, unmatchedExpectedCases }) => {
       describe('matched', () => {
         test.each(matchedExpectedCases)('expected: $expected', async ({ expected }) => {
-          // @ts-expect-error
           await expect.each(values.map(it => () => Promise.reject(it)))
             .rejects
             .toBeCloseTo(...expected)
@@ -300,7 +346,6 @@ describe('expect.each()', () => {
       describe('unmatched to throw', () => {
         test.each(unmatchedExpectedCases)('expected: $expected', async ({ expected }) => {
           await expect(() =>
-            // @ts-expect-error
             expect.each(values.map(it => () => Promise.reject(it)))
               .rejects
               .toBeCloseTo(...expected)
@@ -315,6 +360,17 @@ describe('expect.each()', () => {
 
 describe('expect.each()', () => {
   describe('.rejects.not.toBeCloseTo()', () => {
+    /**
+     * @type {Array<{
+     *   values: Array<number>
+     *   matchedExpectedCases: Array<{
+     *     expected: [number, number]
+     *   }>
+     *   unmatchedExpectedCases: Array<{
+     *     expected: [number, number]
+     *   }>
+     * }>}
+     */
     const cases = [
       {
         values: [
@@ -353,7 +409,6 @@ describe('expect.each()', () => {
     describe.each(cases)('values: $values', ({ values, matchedExpectedCases, unmatchedExpectedCases }) => {
       describe('matched', () => {
         test.each(matchedExpectedCases)('expected: $expected', async ({ expected }) => {
-          // @ts-expect-error
           await expect.each(values.map(it => () => Promise.reject(it)))
             .rejects
             .not
@@ -364,7 +419,6 @@ describe('expect.each()', () => {
       describe('unmatched to throw', () => {
         test.each(unmatchedExpectedCases)('expected: $expected', async ({ expected }) => {
           await expect(() =>
-            // @ts-expect-error
             expect.each(values.map(it => () => Promise.reject(it)))
               .rejects
               .not
@@ -383,6 +437,14 @@ describe('expect.each()', () => {
 describe('expect.each()', () => {
   describe('.toBeCloseTo.each()', () => {
     describe('lacked expected values', () => {
+      /**
+       * @type {Array<{
+       *   actualValues: Array<number>
+       *   lackedCases: Array<{
+       *     expectedValues: Array<[number, number]>
+       *   }>
+       * }>}
+       */
       const cases = [
         {
           actualValues: [
@@ -411,7 +473,6 @@ describe('expect.each()', () => {
       describe.each(cases)('actual values: $actualValues', ({ actualValues, lackedCases }) => {
         test.each(lackedCases)('expected values: $expectedValues', ({ expectedValues }) => {
           expect(() =>
-            // @ts-expect-error
             expect.each(actualValues)
               .toBeCloseTo.each(expectedValues)
           )
@@ -421,6 +482,14 @@ describe('expect.each()', () => {
     })
 
     describe('excess expected values', () => {
+      /**
+       * @type {Array<{
+       *   actualValues: Array<number>
+       *   excessCases: Array<{
+       *     expectedValues: Array<[number, number]>
+       *   }>
+       * }>}
+       */
       const cases = [
         {
           actualValues: [
@@ -447,7 +516,6 @@ describe('expect.each()', () => {
       describe.each(cases)('actual values: $actualValues', ({ actualValues, excessCases }) => {
         test.each(excessCases)('expected values: $expectedValues', ({ expectedValues }) => {
           expect(() =>
-            // @ts-expect-error
             expect.each(actualValues)
               .toBeCloseTo.each(expectedValues)
           )
@@ -457,6 +525,12 @@ describe('expect.each()', () => {
     })
 
     describe('matched', () => {
+      /**
+       * @type {Array<{
+       *   actualValues: Array<number>
+       *   expectedValues: Array<[number, number]>
+       * }>}
+       */
       const cases = [
         {
           actualValues: [
@@ -483,13 +557,20 @@ describe('expect.each()', () => {
       ]
 
       test.each(cases)('actual values: $actualValues', ({ actualValues, expectedValues }) => {
-        // @ts-expect-error
         expect.each(actualValues)
           .toBeCloseTo.each(expectedValues)
       })
     })
 
     describe('unmatched to throw', () => {
+      /**
+       * @type {Array<{
+       *   actualValues: Array<number>
+       *   unmatchedCases: Array<{
+       *     expectedValues: Array<[number, number]>
+       *   }>
+       * }>}
+       */
       const cases = [
         {
           actualValues: [
@@ -546,7 +627,6 @@ describe('expect.each()', () => {
       describe.each(cases)('actual values: $actualValues', ({ actualValues, unmatchedCases }) => {
         test.each(unmatchedCases)('expected values: $expectedValues', ({ expectedValues }) => {
           expect(() =>
-            // @ts-expect-error
             expect.each(actualValues)
               .toBeCloseTo.each(expectedValues)
           )
@@ -560,6 +640,14 @@ describe('expect.each()', () => {
 describe('expect.each()', () => {
   describe('.not.toBeCloseTo.each()', () => {
     describe('lacked expected values', () => {
+      /**
+       * @type {Array<{
+       *   actualValues: Array<number>
+       *   lackedCases: Array<{
+       *     expectedValues: Array<[number, number]>
+       *   }>
+       * }>}
+       */
       const cases = [
         {
           actualValues: [
@@ -588,7 +676,6 @@ describe('expect.each()', () => {
       describe.each(cases)('actual values: $actualValues', ({ actualValues, lackedCases }) => {
         test.each(lackedCases)('expected values: $expectedValues', ({ expectedValues }) => {
           expect(() =>
-            // @ts-expect-error
             expect.each(actualValues)
               .not
               .toBeCloseTo.each(expectedValues)
@@ -599,6 +686,14 @@ describe('expect.each()', () => {
     })
 
     describe('excess expected values', () => {
+      /**
+       * @type {Array<{
+       *   actualValues: Array<number>
+       *   excessCases: Array<{
+       *     expectedValues: Array<[number, number]>
+       *   }>
+       * }>}
+       */
       const cases = [
         {
           actualValues: [
@@ -625,7 +720,6 @@ describe('expect.each()', () => {
       describe.each(cases)('actual values: $actualValues', ({ actualValues, excessCases }) => {
         test.each(excessCases)('expected values: $expectedValues', ({ expectedValues }) => {
           expect(() =>
-            // @ts-expect-error
             expect.each(actualValues)
               .not
               .toBeCloseTo.each(expectedValues)
@@ -636,6 +730,14 @@ describe('expect.each()', () => {
     })
 
     describe('matched', () => {
+      /**
+       * @type {Array<{
+       *   actualValues: Array<number>
+       *   matchedCases: Array<{
+       *     expectedValues: Array<[number, number]>
+       *   }>
+       * }>}
+       */
       const cases = [
         {
           actualValues: [
@@ -684,7 +786,6 @@ describe('expect.each()', () => {
 
       describe.each(cases)('actual values: $actualValues', ({ actualValues, matchedCases }) => {
         test.each(matchedCases)('expected values: $expectedValues', ({ expectedValues }) => {
-          // @ts-expect-error
           expect.each(actualValues)
             .not
             .toBeCloseTo.each(expectedValues)
@@ -693,6 +794,12 @@ describe('expect.each()', () => {
     })
 
     describe('unmatched to throw', () => {
+      /**
+       * @type {Array<{
+       *   actualValues: Array<number>
+       *   expectedValues: Array<[number, number]>
+       * }>}
+       */
       const cases = [
         {
           actualValues: [
@@ -720,7 +827,6 @@ describe('expect.each()', () => {
 
       test.each(cases)('actual values: $actualValues', ({ actualValues, expectedValues }) => {
         expect(() =>
-          // @ts-expect-error
           expect.each(actualValues)
             .not
             .toBeCloseTo.each(expectedValues)
@@ -734,6 +840,14 @@ describe('expect.each()', () => {
 describe('expect.each()', () => {
   describe('.resolves.toBeCloseTo.each()', () => {
     describe('lacked expected values', () => {
+      /**
+       * @type {Array<{
+       *   actualValues: Array<number>
+       *   lackedCases: Array<{
+       *     expectedValues: Array<[number, number]>
+       *   }>
+       * }>}
+       */
       const cases = [
         {
           actualValues: [
@@ -762,7 +876,6 @@ describe('expect.each()', () => {
       describe.each(cases)('actual values: $actualValues', ({ actualValues, lackedCases }) => {
         test.each(lackedCases)('expected values: $expectedValues', async ({ expectedValues }) => {
           await expect(() =>
-            // @ts-expect-error
             expect.each(actualValues)
               .resolves
               .toBeCloseTo.each(expectedValues)
@@ -774,6 +887,14 @@ describe('expect.each()', () => {
     })
 
     describe('excess expected values', () => {
+      /**
+       * @type {Array<{
+       *   actualValues: Array<number>
+       *   excessCases: Array<{
+       *     expectedValues: Array<[number, number]>
+       *   }>
+       * }>}
+       */
       const cases = [
         {
           actualValues: [
@@ -800,7 +921,6 @@ describe('expect.each()', () => {
       describe.each(cases)('actual values: $actualValues', ({ actualValues, excessCases }) => {
         test.each(excessCases)('expected values: $expectedValues', async ({ expectedValues }) => {
           await expect(() =>
-            // @ts-expect-error
             expect.each(actualValues)
               .resolves
               .toBeCloseTo.each(expectedValues)
@@ -812,6 +932,12 @@ describe('expect.each()', () => {
     })
 
     describe('matched', () => {
+      /**
+       * @type {Array<{
+       *   actualValues: Array<number>
+       *   expectedValues: Array<[number, number]>
+       * }>}
+       */
       const cases = [
         {
           actualValues: [
@@ -838,7 +964,6 @@ describe('expect.each()', () => {
       ]
 
       test.each(cases)('actual values: $actualValues', async ({ actualValues, expectedValues }) => {
-        // @ts-expect-error
         await expect.each(actualValues.map(it => Promise.resolve(it)))
           .resolves
           .toBeCloseTo.each(expectedValues)
@@ -846,6 +971,14 @@ describe('expect.each()', () => {
     })
 
     describe('unmatched to throw', () => {
+      /**
+       * @type {Array<{
+       *   actualValues: Array<number>
+       *   unmatchedCases: Array<{
+       *     expectedValues: Array<[number, number]>
+       *   }>
+       * }>}
+       */
       const cases = [
         {
           actualValues: [
@@ -902,7 +1035,6 @@ describe('expect.each()', () => {
       describe.each(cases)('actual values: $actualValues', ({ actualValues, unmatchedCases }) => {
         test.each(unmatchedCases)('expected values: $expectedValues', async ({ expectedValues }) => {
           await expect(() =>
-            // @ts-expect-error
             expect.each(actualValues.map(it => Promise.resolve(it)))
               .resolves
               .toBeCloseTo.each(expectedValues)
@@ -918,6 +1050,14 @@ describe('expect.each()', () => {
 describe('expect.each()', () => {
   describe('.resolves.not.toBeCloseTo.each()', () => {
     describe('lacked expected values', () => {
+      /**
+       * @type {Array<{
+       *   actualValues: Array<number>
+       *   lackedCases: Array<{
+       *     expectedValues: Array<[number, number]>
+       *   }>
+       * }>}
+       */
       const cases = [
         {
           actualValues: [
@@ -946,7 +1086,6 @@ describe('expect.each()', () => {
       describe.each(cases)('actual values: $actualValues', ({ actualValues, lackedCases }) => {
         test.each(lackedCases)('expected values: $expectedValues', async ({ expectedValues }) => {
           await expect(() =>
-            // @ts-expect-error
             expect.each(actualValues)
               .resolves
               .not
@@ -959,6 +1098,14 @@ describe('expect.each()', () => {
     })
 
     describe('excess expected values', () => {
+      /**
+       * @type {Array<{
+       *   actualValues: Array<number>
+       *   excessCases: Array<{
+       *     expectedValues: Array<[number, number]>
+       *   }>
+       * }>}
+       */
       const cases = [
         {
           actualValues: [
@@ -985,7 +1132,6 @@ describe('expect.each()', () => {
       describe.each(cases)('actual values: $actualValues', ({ actualValues, excessCases }) => {
         test.each(excessCases)('expected values: $expectedValues', async ({ expectedValues }) => {
           await expect(() =>
-            // @ts-expect-error
             expect.each(actualValues)
               .resolves
               .not
@@ -998,6 +1144,12 @@ describe('expect.each()', () => {
     })
 
     describe('matched', () => {
+      /**
+       * @type {Array<{
+       *   actualValues: Array<number>
+       *   expectedValues: Array<[number, number]>
+       * }>}
+       */
       const cases = [
         {
           actualValues: [
@@ -1024,7 +1176,6 @@ describe('expect.each()', () => {
       ]
 
       test.each(cases)('actual values: $actualValues', async ({ actualValues, expectedValues }) => {
-        // @ts-expect-error
         await expect.each(actualValues.map(it => Promise.resolve(it)))
           .resolves
           .not
@@ -1033,6 +1184,14 @@ describe('expect.each()', () => {
     })
 
     describe('unmatched to throw', () => {
+      /**
+       * @type {Array<{
+       *   actualValues: Array<number>
+       *   unmatchedCases: Array<{
+       *     expectedValues: Array<[number, number]>
+       *   }>
+       * }>}
+       */
       const cases = [
         {
           actualValues: [
@@ -1089,7 +1248,6 @@ describe('expect.each()', () => {
       describe.each(cases)('actual values: $actualValues', ({ actualValues, unmatchedCases }) => {
         test.each(unmatchedCases)('expected values: $expectedValues', async ({ expectedValues }) => {
           await expect(() =>
-            // @ts-expect-error
             expect.each(actualValues.map(it => Promise.resolve(it)))
               .resolves
               .not
@@ -1106,6 +1264,14 @@ describe('expect.each()', () => {
 describe('expect.each()', () => {
   describe('.rejects.toBeCloseTo.each()', () => {
     describe('lacked expected values', () => {
+      /**
+       * @type {Array<{
+       *   actualValues: Array<number>
+       *   lackedCases: Array<{
+       *     expectedValues: Array<[number, number]>
+       *   }>
+       * }>}
+       */
       const cases = [
         {
           actualValues: [
@@ -1134,7 +1300,6 @@ describe('expect.each()', () => {
       describe.each(cases)('actual values: $actualValues', ({ actualValues, lackedCases }) => {
         test.each(lackedCases)('expected values: $expectedValues', async ({ expectedValues }) => {
           await expect(() =>
-            // @ts-expect-error
             expect.each(actualValues.map(it => () => Promise.reject(it)))
               .rejects
               .toBeCloseTo.each(expectedValues)
@@ -1146,6 +1311,14 @@ describe('expect.each()', () => {
     })
 
     describe('excess expected values', () => {
+      /**
+       * @type {Array<{
+       *   actualValues: Array<number>
+       *   excessCases: Array<{
+       *     expectedValues: Array<[number, number]>
+       *   }>
+       * }>}
+       */
       const cases = [
         {
           actualValues: [
@@ -1172,7 +1345,6 @@ describe('expect.each()', () => {
       describe.each(cases)('actual values: $actualValues', ({ actualValues, excessCases }) => {
         test.each(excessCases)('expected values: $expectedValues', async ({ expectedValues }) => {
           await expect(() =>
-            // @ts-expect-error
             expect.each(actualValues.map(it => () => Promise.reject(it)))
               .rejects
               .toBeCloseTo.each(expectedValues)
@@ -1184,6 +1356,12 @@ describe('expect.each()', () => {
     })
 
     describe('matched', () => {
+      /**
+       * @type {Array<{
+       *   actualValues: Array<number>
+       *   expectedValues: Array<[number, number]>
+       * }>}
+       */
       const cases = [
         {
           actualValues: [
@@ -1210,7 +1388,6 @@ describe('expect.each()', () => {
       ]
 
       test.each(cases)('actual values: $actualValues', async ({ actualValues, expectedValues }) => {
-        // @ts-expect-error
         await expect.each(actualValues.map(it => () => Promise.reject(it)))
           .rejects
           .toBeCloseTo.each(expectedValues)
@@ -1218,6 +1395,14 @@ describe('expect.each()', () => {
     })
 
     describe('unmatched to throw', () => {
+      /**
+       * @type {Array<{
+       *   actualValues: Array<number>
+       *   unmatchedCases: Array<{
+       *     expectedValues: Array<[number, number]>
+       *   }>
+       * }>}
+       */
       const cases = [
         {
           actualValues: [
@@ -1274,7 +1459,6 @@ describe('expect.each()', () => {
       describe.each(cases)('actual values: $actualValues', ({ actualValues, unmatchedCases }) => {
         test.each(unmatchedCases)('expected values: $expectedValues', async ({ expectedValues }) => {
           await expect(() =>
-            // @ts-expect-error
             expect.each(actualValues.map(it => () => Promise.reject(it)))
               .rejects
               .toBeCloseTo.each(expectedValues)
@@ -1290,6 +1474,14 @@ describe('expect.each()', () => {
 describe('expect.each()', () => {
   describe('.rejects.not.toBeCloseTo.each()', () => {
     describe('lacked expected values', () => {
+      /**
+       * @type {Array<{
+       *   actualValues: Array<number>
+       *   lackedCases: Array<{
+       *     expectedValues: Array<[number, number]>
+       *   }>
+       * }>}
+       */
       const cases = [
         {
           actualValues: [
@@ -1318,7 +1510,6 @@ describe('expect.each()', () => {
       describe.each(cases)('actual values: $actualValues', ({ actualValues, lackedCases }) => {
         test.each(lackedCases)('expected values: $expectedValues', async ({ expectedValues }) => {
           await expect(() =>
-            // @ts-expect-error
             expect.each(actualValues.map(it => () => Promise.reject(it)))
               .rejects
               .not

--- a/tests/__tests__/expect.each/toBeCloseTo.js
+++ b/tests/__tests__/expect.each/toBeCloseTo.js
@@ -1526,7 +1526,7 @@ describe('expect.each()', () => {
        * @type {Array<{
        *   actualValues: Array<*>
        *   excessCases: Array<{
-       *     expectedValues: Array<*>
+       *     expectedValues: Array<number | [number, number?]>
        *   }>
        * }>}
        */
@@ -1537,14 +1537,6 @@ describe('expect.each()', () => {
             { expectedValues: [1, 2, 3, 4] },
             { expectedValues: [1, 2, 3, 4, 5] },
             { expectedValues: [1, 2, 3, 4, 5, 6] },
-          ],
-        },
-        {
-          actualValues: ['alpha', 'beta', 'gamma', 'delta'],
-          excessCases: [
-            { expectedValues: ['alpha', 'beta', 'gamma', 'delta', 'epsilon'] },
-            { expectedValues: ['alpha', 'beta', 'gamma', 'delta', 'epsilon', 'zeta'] },
-            { expectedValues: ['alpha', 'beta', 'gamma', 'delta', 'epsilon', 'zeta', 'eta'] },
           ],
         },
         {

--- a/tests/__tests__/expect.each/toBeCloseTo.js
+++ b/tests/__tests__/expect.each/toBeCloseTo.js
@@ -1371,7 +1371,6 @@ describe('expect.each()', () => {
       describe.each(cases)('actual values: $actualValues', ({ actualValues, excessCases }) => {
         test.each(excessCases)('expected values: $expectedValues', async ({ expectedValues }) => {
           await expect(() =>
-            // @ts-expect-error
             expect.each(actualValues.map(it => () => Promise.reject(it)))
               .rejects
               .not
@@ -1384,6 +1383,14 @@ describe('expect.each()', () => {
     })
 
     describe('matched', () => {
+      /**
+       * @type {Array<{
+       *   actualValues: Array<number>
+       *   unmatchedCases: Array<{
+       *     expectedValues: Array<[number, number]>
+       *   }>
+       * }>}
+       */
       const cases = [
         {
           actualValues: [
@@ -1432,7 +1439,6 @@ describe('expect.each()', () => {
 
       describe.each(cases)('actual values: $actualValues', ({ actualValues, unmatchedCases }) => {
         test.each(unmatchedCases)('expected values: $expectedValues', async ({ expectedValues }) => {
-          // @ts-expect-error
           await expect.each(actualValues.map(it => () => Promise.reject(it)))
             .rejects
             .not
@@ -1442,6 +1448,12 @@ describe('expect.each()', () => {
     })
 
     describe('unmatched to throw', () => {
+      /**
+       * @type {Array<{
+       *   actualValues: Array<number>
+       *   expectedValues: Array<[number, number]>
+       * }>}
+       */
       const cases = [
         {
           actualValues: [
@@ -1469,7 +1481,6 @@ describe('expect.each()', () => {
 
       test.each(cases)('actual values: $actualValues', async ({ actualValues, expectedValues }) => {
         await expect(() =>
-          // @ts-expect-error
           expect.each(actualValues.map(it => () => Promise.reject(it)))
             .rejects
             .not

--- a/tests/__tests__/expect.each/toBeNull.js
+++ b/tests/__tests__/expect.each/toBeNull.js
@@ -10,7 +10,6 @@ describe('expect.each()', () => {
       ]
 
       test.each(cases)('length: $values.length', ({ values }) => {
-        // @ts-expect-error
         expect.each(values)
           .toBeNull()
       })
@@ -43,7 +42,6 @@ describe('expect.each()', () => {
 
       test.each(cases)('values: $values', ({ values }) => {
         expect(() =>
-          // @ts-expect-error
           expect.each(values)
             .toBeNull()
         )
@@ -82,7 +80,6 @@ describe('expect.each()', () => {
       ]
 
       test.each(cases)('length: $values.length', ({ values }) => {
-        // @ts-expect-error
         expect.each(values)
           .not
           .toBeNull()
@@ -116,7 +113,6 @@ describe('expect.each()', () => {
 
       test.each(cases)('values: $values', ({ values }) => {
         expect(() =>
-          // @ts-expect-error
           expect.each(values)
             .not
             .toBeNull()
@@ -137,7 +133,6 @@ describe('expect.each()', () => {
       ]
 
       test.each(cases)('length: $values.length', async ({ values }) => {
-        // @ts-expect-error
         await expect.each(values.map(it => Promise.resolve(it)))
           .resolves
           .toBeNull()
@@ -171,7 +166,6 @@ describe('expect.each()', () => {
 
       test.each(cases)('values: $values', async ({ values }) => {
         await expect(
-          // @ts-expect-error
           expect.each(values.map(it => Promise.resolve(it)))
             .resolves
             .toBeNull()
@@ -212,7 +206,6 @@ describe('expect.each()', () => {
       ]
 
       test.each(cases)('length: $values.length', async ({ values }) => {
-        // @ts-expect-error
         await expect.each(values.map(it => Promise.resolve(it)))
           .resolves
           .not
@@ -247,7 +240,6 @@ describe('expect.each()', () => {
 
       test.each(cases)('values: $values', async ({ values }) => {
         await expect(
-          // @ts-expect-error
           expect.each(values.map(it => Promise.resolve(it)))
             .resolves
             .not
@@ -270,7 +262,6 @@ describe('expect.each()', () => {
       ]
 
       test.each(cases)('length: $values.length', async ({ values }) => {
-        // @ts-expect-error
         await expect.each(values.map(it => () => Promise.reject(it)))
           .rejects
           .toBeNull()
@@ -304,7 +295,6 @@ describe('expect.each()', () => {
 
       test.each(cases)('values: $values', async ({ values }) => {
         await expect(
-          // @ts-expect-error
           expect.each(values.map(it => () => Promise.reject(it)))
             .rejects
             .toBeNull()
@@ -345,7 +335,6 @@ describe('expect.each()', () => {
       ]
 
       test.each(cases)('length: $values.length', async ({ values }) => {
-        // @ts-expect-error
         await expect.each(values.map(it => () => Promise.reject(it)))
           .rejects
           .not
@@ -380,7 +369,6 @@ describe('expect.each()', () => {
 
       test.each(cases)('values: $values', async ({ values }) => {
         await expect(
-          // @ts-expect-error
           expect.each(values.map(it => () => Promise.reject(it)))
             .rejects
             .not
@@ -417,7 +405,6 @@ describe('expect.each()', () => {
       describe.each(cases)('actual values: $actualValues', ({ actualValues, lackedCases }) => {
         test.each(lackedCases)('length: $expectedValues.length', ({ expectedValues }) => {
           expect(() =>
-            // @ts-expect-error
             expect.each(actualValues)
               .toBeNull.each(expectedValues)
           )
@@ -447,7 +434,6 @@ describe('expect.each()', () => {
       describe.each(cases)('actual values: $actualValues', ({ actualValues, excessCases }) => {
         test.each(excessCases)('length: $expectedValues.length', ({ expectedValues }) => {
           expect(() =>
-            // @ts-expect-error
             expect.each(actualValues)
               .toBeNull.each(expectedValues)
           )
@@ -470,7 +456,6 @@ describe('expect.each()', () => {
 
       test.each(cases)('actual values: $actualValues', ({ actualValues, expectedValues }) => {
         expect(() =>
-          // @ts-expect-error
           expect.each(actualValues)
             .toBeNull.each(expectedValues)
         )
@@ -523,7 +508,6 @@ describe('expect.each()', () => {
       describe.each(cases)('actual values: $actualValues', ({ actualValues, lackedCases }) => {
         test.each(lackedCases)('length: $expectedValues.length', ({ expectedValues }) => {
           expect(() =>
-            // @ts-expect-error
             expect.each(actualValues)
               .not
               .toBeNull.each(expectedValues)
@@ -554,7 +538,6 @@ describe('expect.each()', () => {
       describe.each(cases)('actual values: $actualValues', ({ actualValues, excessCases }) => {
         test.each(excessCases)('length: $expectedValues.length', ({ expectedValues }) => {
           expect(() =>
-            // @ts-expect-error
             expect.each(actualValues)
               .not
               .toBeNull.each(expectedValues)
@@ -578,7 +561,6 @@ describe('expect.each()', () => {
 
       test.each(cases)('actual values: $actualValues', ({ actualValues, expectedValues }) => {
         expect(() =>
-          // @ts-expect-error
           expect.each(actualValues)
             .not
             .toBeNull.each(expectedValues)
@@ -632,7 +614,6 @@ describe('expect.each()', () => {
       describe.each(cases)('actual values: $actualValues', ({ actualValues, lackedCases }) => {
         test.each(lackedCases)('length: $expectedValues.length', async ({ expectedValues }) => {
           await expect(() =>
-            // @ts-expect-error
             expect.each(actualValues.map(it => Promise.resolve(it)))
               .resolves
               .toBeNull.each(expectedValues)
@@ -664,7 +645,6 @@ describe('expect.each()', () => {
       describe.each(cases)('actual values: $actualValues', ({ actualValues, excessCases }) => {
         test.each(excessCases)('length: $expectedValues.length', async ({ expectedValues }) => {
           await expect(() =>
-            // @ts-expect-error
             expect.each(actualValues.map(it => Promise.resolve(it)))
               .resolves
               .toBeNull.each(expectedValues)
@@ -689,7 +669,6 @@ describe('expect.each()', () => {
 
       test.each(cases)('actual values: $actualValues', async ({ actualValues, expectedValues }) => {
         await expect(() =>
-          // @ts-expect-error
           expect.each(actualValues.map(it => Promise.resolve(it)))
             .resolves
             .toBeNull.each(expectedValues)
@@ -744,7 +723,6 @@ describe('expect.each()', () => {
       describe.each(cases)('actual values: $actualValues', ({ actualValues, lackedCases }) => {
         test.each(lackedCases)('length: $expectedValues.length', async ({ expectedValues }) => {
           await expect(() =>
-            // @ts-expect-error
             expect.each(actualValues.map(it => Promise.resolve(it)))
               .resolves
               .not
@@ -777,7 +755,6 @@ describe('expect.each()', () => {
       describe.each(cases)('actual values: $actualValues', ({ actualValues, excessCases }) => {
         test.each(excessCases)('length: $expectedValues.length', async ({ expectedValues }) => {
           await expect(() =>
-            // @ts-expect-error
             expect.each(actualValues.map(it => Promise.resolve(it)))
               .resolves
               .not
@@ -803,7 +780,6 @@ describe('expect.each()', () => {
 
       test.each(cases)('actual values: $actualValues', async ({ actualValues, expectedValues }) => {
         await expect(() =>
-          // @ts-expect-error
           expect.each(actualValues.map(it => Promise.resolve(it)))
             .resolves
             .not
@@ -859,7 +835,6 @@ describe('expect.each()', () => {
       describe.each(cases)('actual values: $actualValues', ({ actualValues, lackedCases }) => {
         test.each(lackedCases)('length: $expectedValues.length', async ({ expectedValues }) => {
           await expect(() =>
-            // @ts-expect-error
             expect.each(actualValues.map(it => () => Promise.reject(it)))
               .rejects
               .toBeNull.each(expectedValues)
@@ -891,7 +866,6 @@ describe('expect.each()', () => {
       describe.each(cases)('actual values: $actualValues', ({ actualValues, excessCases }) => {
         test.each(excessCases)('length: $expectedValues.length', async ({ expectedValues }) => {
           await expect(() =>
-            // @ts-expect-error
             expect.each(actualValues.map(it => () => Promise.reject(it)))
               .rejects
               .toBeNull.each(expectedValues)
@@ -916,7 +890,6 @@ describe('expect.each()', () => {
 
       test.each(cases)('actual values: $actualValues', async ({ actualValues, expectedValues }) => {
         await expect(() =>
-          // @ts-expect-error
           expect.each(actualValues.map(it => () => Promise.reject(it)))
             .rejects
             .toBeNull.each(expectedValues)
@@ -971,7 +944,6 @@ describe('expect.each()', () => {
       describe.each(cases)('actual values: $actualValues', ({ actualValues, lackedCases }) => {
         test.each(lackedCases)('length: $expectedValues.length', async ({ expectedValues }) => {
           await expect(() =>
-            // @ts-expect-error
             expect.each(actualValues.map(it => () => Promise.reject(it)))
               .rejects
               .not
@@ -1004,7 +976,6 @@ describe('expect.each()', () => {
       describe.each(cases)('actual values: $actualValues', ({ actualValues, excessCases }) => {
         test.each(excessCases)('length: $expectedValues.length', async ({ expectedValues }) => {
           await expect(() =>
-            // @ts-expect-error
             expect.each(actualValues.map(it => () => Promise.reject(it)))
               .rejects
               .not
@@ -1030,7 +1001,6 @@ describe('expect.each()', () => {
 
       test.each(cases)('actual values: $actualValues', async ({ actualValues, expectedValues }) => {
         await expect(() =>
-          // @ts-expect-error
           expect.each(actualValues.map(it => () => Promise.reject(it)))
             .rejects
             .not

--- a/types/jest-expect.each.d.ts
+++ b/types/jest-expect.each.d.ts
@@ -1,0 +1,52 @@
+// types/jest-expect.each.d.ts
+declare global {
+  namespace jest {
+    interface Expect {
+      /**
+       * Test multiple values against the same matcher
+       * @example
+       * expect.each([1, 2, 3]).toBe(expected)
+       * expect.each([1, 2, 3]).toBe.each([1, 2, 3])
+       */
+      each<T>(actualValues: Array<T>): ExpectEachProxy<T>
+    }
+  }
+}
+
+type MatchersToEach<M> = {
+  [K in keyof M]: M[K] extends (...args: any[]) => any
+    ? MatcherWithEach<M[K]>
+    : M[K]
+}
+
+type MatchersToEachAsync<M> = {
+  [K in keyof M]: M[K] extends (...args: any[]) => any
+    ? MatcherWithEachAsync<M[K]>
+    : M[K]
+}
+
+interface ExpectEachProxy<T> extends MatchersToEach<jest.Matchers<void>> {
+  not: MatchersToEach<jest.Matchers<void>>
+  resolves: MatchersToEachAsync<jest.Matchers<any>> & {
+    not: MatchersToEachAsync<jest.Matchers<any>>
+  }
+  rejects: MatchersToEachAsync<jest.Matchers<any>> & {
+    not: MatchersToEachAsync<jest.Matchers<any>>
+  }
+}
+
+type MatcherWithEach<F> = F extends (...args: infer Args) => infer R
+  ? {
+      (...args: Args): R
+      each(expectedValues: Array<Args | Args[0]>): R
+    }
+  : never
+
+type MatcherWithEachAsync<F> = F extends (...args: infer Args) => any
+  ? {
+      (...args: Args): Promise<void>
+      each(expectedValues: Array<Args | Args[0]>): Promise<void>
+    }
+  : never
+
+export {}


### PR DESCRIPTION
## Why

* Close #39

## How

* All commits have already been reviewed, merge only
